### PR TITLE
Skill Damage events fixes + Critical Chance for non-player Entities

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ forgeVersion=43.3.5
 # Parchment Version
 parchmentVersion=2022.11.27
 # Mod Information see https://mcforge.readthedocs.io/en/1.18.x/gettingstarted/versioning/#examples
-modVersion=2.1.3.6
+modVersion=2.1.3.7
 modId=manascore
 # Mixin Extras
 mixinExtrasVersion=0.3.2

--- a/src/main/java/com/github/manasmods/manascore/api/skills/event/SkillDamageEvent.java
+++ b/src/main/java/com/github/manasmods/manascore/api/skills/event/SkillDamageEvent.java
@@ -1,7 +1,6 @@
 package com.github.manasmods.manascore.api.skills.event;
 
 import lombok.Getter;
-import lombok.Setter;
 import net.minecraft.world.damagesource.DamageSource;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraftforge.event.entity.living.LivingHurtEvent;
@@ -17,19 +16,41 @@ import org.jetbrains.annotations.ApiStatus;
 public class SkillDamageEvent extends Event {
     @Getter
     private final LivingHurtEvent event;
-    @Getter
-    private final LivingEntity entity;
-    @Getter
-    private final DamageSource source;
-    @Getter
-    @Setter
-    private float amount;
 
     public SkillDamageEvent(LivingHurtEvent event) {
         this.event = event;
-        this.entity = event.getEntity();
-        this.source = event.getSource();
-        this.amount = event.getAmount();
+    }
+
+    public LivingEntity getEntity() {
+        return this.event.getEntity();
+    }
+
+    public DamageSource getSource() {
+        return this.event.getSource();
+    }
+
+    public float getAmount() {
+        return this.event.getAmount();
+    }
+
+    public void setAmount(float amount) {
+        this.event.setAmount(amount);
+    }
+
+    public boolean isCanceled() {
+        return this.event.isCanceled();
+    }
+
+    public void setCanceled(boolean cancel) {
+        this.event.setCanceled(cancel);
+    }
+
+    public Result getResult() {
+        return this.event.getResult();
+    }
+
+    public void setResult(Result value) {
+        this.event.setResult(value);
     }
 
     /**


### PR DESCRIPTION
# Description

Skill Damage events fixes + Critical Chance for non-player Entities

## List of changes

- Skill Damage events not working as intended with **setCanceled()**
- Making Crit Chance/Multiplier work with non-player Entities.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code Refactoring (non-breaking change which improved the Code Quality)
- [ ] Breaking Code Refactoring (breaking change which improved the Code Quality)
- [ ] Documentation update (JavaDoc or Markdown change)
