### PR TITLE
Removal Time & Sweeping edge shorter range

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ forgeVersion=43.3.5
 # Parchment Version
 parchmentVersion=2022.11.27
 # Mod Information see https://mcforge.readthedocs.io/en/1.18.x/gettingstarted/versioning/#examples
-modVersion=2.1.3.7
+modVersion=2.1.3.8
 modId=manascore
 # Mixin Extras
 mixinExtrasVersion=0.3.2

--- a/src/main/java/com/github/manasmods/manascore/api/skills/ManasSkillInstance.java
+++ b/src/main/java/com/github/manasmods/manascore/api/skills/ManasSkillInstance.java
@@ -309,7 +309,14 @@ public class ManasSkillInstance implements Cloneable {
     }
 
     /**
-     * Set the remove time of this instance.
+     * @return the removal time of this instance.
+     */
+    public int getRemoveTime() {
+        return this.removeTime;
+    }
+
+    /**
+     * Set the removal time of this instance.
      */
     public void setRemoveTime(int removeTime) {
         this.removeTime = removeTime;
@@ -317,7 +324,7 @@ public class ManasSkillInstance implements Cloneable {
     }
 
     /**
-     * Decrease the remove time of this instance.
+     * Decrease the removal time of this instance.
      */
     public void decreaseRemoveTime(int time) {
         this.removeTime -= time;

--- a/src/main/java/com/github/manasmods/manascore/network/toserver/RequestSweepChancePacket.java
+++ b/src/main/java/com/github/manasmods/manascore/network/toserver/RequestSweepChancePacket.java
@@ -37,7 +37,7 @@ public class RequestSweepChancePacket {
     }
 
     private void sweepAttack(Player player) {
-        double radiusAddition = player.getAttackRange() / 2;
+        double radiusAddition = player.getAttackRange() / 2 - 1;
         float sweepAttack = 1.0F + getSweepingDamageRatio(player) * getAttackDamage(player);
 
         AABB sweepArea = player.getBoundingBox().inflate(1.0 + radiusAddition, 0.25, 1.0 + radiusAddition)

--- a/src/main/java/com/github/manasmods/manascore/network/toserver/RequestSweepChancePacket.java
+++ b/src/main/java/com/github/manasmods/manascore/network/toserver/RequestSweepChancePacket.java
@@ -37,7 +37,7 @@ public class RequestSweepChancePacket {
     }
 
     private void sweepAttack(Player player) {
-        double radiusAddition = player.getAttackRange() / 2 - 1;
+        double radiusAddition = (player.getAttackRange() - 1) / 2;
         float sweepAttack = 1.0F + getSweepingDamageRatio(player) * getAttackDamage(player);
 
         AABB sweepArea = player.getBoundingBox().inflate(1.0 + radiusAddition, 0.25, 1.0 + radiusAddition)


### PR DESCRIPTION
# Description
Removal Time & Sweeping edge shorter range

## List of changes

- Added a method to get the skill instance's removal time.
- Makes Sweeping Chance's range shorter

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code Refactoring (non-breaking change which improved the Code Quality)
- [ ] Breaking Code Refactoring (breaking change which improved the Code Quality)
- [ ] Documentation update (JavaDoc or Markdown change)
