### PR TITLE
Critical Chance Event bugged

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ forgeVersion=43.3.5
 # Parchment Version
 parchmentVersion=2022.11.27
 # Mod Information see https://mcforge.readthedocs.io/en/1.18.x/gettingstarted/versioning/#examples
-modVersion=2.1.3.9
+modVersion=2.1.4.0
 modId=manascore
 # Mixin Extras
 mixinExtrasVersion=0.3.2

--- a/src/main/java/com/github/manasmods/manascore/api/attribute/event/CriticalChanceEvent.java
+++ b/src/main/java/com/github/manasmods/manascore/api/attribute/event/CriticalChanceEvent.java
@@ -20,7 +20,8 @@ public class CriticalChanceEvent extends LivingEvent {
     public CriticalChanceEvent(LivingEntity attacker, Entity target, float damageModifier, double critChance) {
         super(attacker);
         this.target = target;
-        this.oldDamageModifier = damageModifier;
         this.critChance = critChance;
+        this.damageModifier = damageModifier;
+        this.oldDamageModifier = damageModifier;
     }
 }


### PR DESCRIPTION
# Description

Forgot to set the new damage modifier for the Critical Chance event.

## List of changes

- Added value initiation for Damage Modifier in Critical Chance event.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code Refactoring (non-breaking change which improved the Code Quality)
- [ ] Breaking Code Refactoring (breaking change which improved the Code Quality)
- [ ] Documentation update (JavaDoc or Markdown change)
