### PR TITLE
Skills Cooldown/Temporary skill tick rework

### DIFF
--- a/skill-common/src/main/java/io/github/manasmods/manascore/skill/api/ManasSkillInstance.java
+++ b/skill-common/src/main/java/io/github/manasmods/manascore/skill/api/ManasSkillInstance.java
@@ -43,11 +43,31 @@ public class ManasSkillInstance {
     @Getter
     private boolean dirty = false;
     protected final RegistrySupplier<ManasSkill> skillRegistryObject;
+    private Skills owningStorage = null;
 
     protected ManasSkillInstance(ManasSkill skill) {
         this.skillRegistryObject = SkillAPI.getSkillRegistry().delegate(SkillAPI.getSkillRegistry().getId(skill));
         this.subInstances = new HashMap<>();
         this.cooldownList = NonNullList.withSize(this.getModes(), 0);
+    }
+
+    /**
+     * Used to get the {@link Skills} which possesses this instance.
+     */
+    public @Nullable Skills getOwningStorage() {
+        return this.owningStorage;
+    }
+
+    /**
+     * Used to determine if the instance has a reference to a storage which should be possessing it.
+     */
+    public boolean hasOwningStorage() {
+        return this.owningStorage != null;
+    }
+
+    @ApiStatus.Internal
+    public void setOwningStorage(Skills storage) {
+        this.owningStorage = storage;
     }
 
     /**
@@ -72,7 +92,9 @@ public class ManasSkillInstance {
         clone.masteryPoint = this.masteryPoint;
         clone.toggled = this.toggled;
         if (this.tag != null) clone.tag = this.tag.copy();
-        clone.subInstances = this.subInstances;
+        for (ManasSkillInstance instance : this.subInstances.values()) {
+            clone.subInstances.put(instance.getSkill(), instance.copy());
+        }
         clone.parentSkill = this.parentSkill;
         return clone;
     }
@@ -161,7 +183,7 @@ public class ManasSkillInstance {
     /**
      * This Method is invoked to indicate that a {@link ManasSkillInstance} has been synced with the clients.
      * <p>
-     * Do <strong>NOT</strong> use that method on our own!
+     * Do <strong>NOT</strong> use this method on your own!
      */
     @ApiStatus.Internal
     public void resetDirty() {
@@ -321,6 +343,9 @@ public class ManasSkillInstance {
      */
     public void setCoolDown(int coolDown, int mode) {
         if (mode < 0 || mode >= cooldownList.size()) return;
+        if (this.hasOwningStorage() && !this.getOwningStorage().shouldActiveTick()) {
+            if (coolDown > 0) this.getOwningStorage().markActiveTick();
+        }
         this.cooldownList.set(mode, coolDown);
         markDirty();
     }
@@ -330,6 +355,9 @@ public class ManasSkillInstance {
      */
     public void setCoolDowns(int coolDown) {
         Collections.fill(this.cooldownList, coolDown);
+        if (this.hasOwningStorage() && !this.getOwningStorage().shouldActiveTick()) {
+            if (coolDown > 0) this.getOwningStorage().shouldActiveTick();
+        }
         markDirty();
     }
 
@@ -339,6 +367,7 @@ public class ManasSkillInstance {
     public void decreaseCoolDown(int coolDown, int mode) {
         if (mode < 0 || mode >= cooldownList.size()) return;
         this.cooldownList.set(mode, Math.max(0, this.cooldownList.get(mode) - coolDown));
+        if (this.hasOwningStorage() && !this.getOwningStorage().shouldActiveTick() && this.getCoolDown(mode) > 0) this.getOwningStorage().markActiveTick();
         markDirty();
     }
 
@@ -347,6 +376,9 @@ public class ManasSkillInstance {
      */
     public void setCoolDownList(List<Integer> list) {
         this.cooldownList = list;
+        if (this.hasOwningStorage() && !this.getOwningStorage().shouldActiveTick()) {
+            for (int i : list) if (i > 0) this.getOwningStorage().markActiveTick();
+        }
     }
 
     /**
@@ -375,6 +407,7 @@ public class ManasSkillInstance {
      */
     public void setRemoveTime(int removeTime) {
         this.removeTime = removeTime;
+        if (removeTime != -1 && hasOwningStorage() && !getOwningStorage().shouldActiveTick()) getOwningStorage().markActiveTick();
         markDirty();
     }
 
@@ -384,6 +417,7 @@ public class ManasSkillInstance {
     public void decreaseRemoveTime(int time) {
         if (this.removeTime > 0) {
             this.removeTime = Math.max(0, this.removeTime - time);
+            if (hasOwningStorage() && !getOwningStorage().shouldActiveTick()) getOwningStorage().markActiveTick();
             markDirty();
         }
     }

--- a/skill-common/src/main/java/io/github/manasmods/manascore/skill/api/Skills.java
+++ b/skill-common/src/main/java/io/github/manasmods/manascore/skill/api/Skills.java
@@ -10,6 +10,8 @@ import lombok.NonNull;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.entity.LivingEntity;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -19,11 +21,36 @@ import java.util.function.BiConsumer;
 
 public interface Skills {
     void markDirty();
+    /**
+     * Marks this to start performing regular active ticks
+     */
+    void markActiveTick();
+    /**
+     * This Method is invoked to indicated that all {@link ManasSkillInstance} objects possessed by this have had their active ticks finished.
+     * <p>
+     * Do <strong>NOT</strong> use this method on your own!
+     */
+    @ApiStatus.Internal
+    void clearActiveTick();
+    /**
+     * Returns if this instance was marked to tick cooldowns using {@link Skills#markActiveTick()}
+     */
+    boolean shouldActiveTick();
+    /**
+     * Returns the LivingEntity to which this object is attached.
+     */
+    LivingEntity getOwner();
 
+    /**
+     * If the provided instance is dirty, marks this as dirty.
+     */
     default void checkAndMarkDirty(ManasSkillInstance instance) {
         if (instance.isDirty()) this.markDirty();
     }
 
+    /**
+     * Returns all {@link ManasSkillInstance} possessed by this object.
+     */
     Collection<ManasSkillInstance> getLearnedSkills();
 
     /**
@@ -34,55 +61,126 @@ public interface Skills {
      */
     void updateSkill(ManasSkillInstance updatedInstance, boolean sync);
 
+    /**
+     * @param skillId The corresponding skill is retrieded from the skill registry, then the storage attempts to learn {@link ManasSkill#createDefaultInstance()}
+     * @return If the storage learned the skill.
+     */
     default boolean learnSkill(@NotNull ResourceLocation skillId) {
         return learnSkill(SkillAPI.getSkillRegistry().get(skillId).createDefaultInstance());
     }
 
+    /**
+     * @param skillId The corresponding skill is retrieded from the skill registry, then the storage attempts to learn {@link ManasSkill#createDefaultInstance()}
+     * @param component Shown to the owner of the storage if the skill was learned successfully.
+     * @return If the storage learned the skill.
+     */
     default boolean learnSkill(@NotNull ResourceLocation skillId, MutableComponent component) {
         return learnSkill(SkillAPI.getSkillRegistry().get(skillId).createDefaultInstance(), component);
     }
 
+    /**
+     * @param skill The storage attempts to learn {@link ManasSkill#createDefaultInstance()}
+     * @return If the storage learned the skill.
+     */
     default boolean learnSkill(@NonNull ManasSkill skill) {
         return learnSkill(skill.createDefaultInstance());
     }
 
+    /**
+     * @param skill The storage attempts to learn {@link ManasSkill#createDefaultInstance()}
+     * @param component Shown to the owner of the storage if the skill was learned successfully.
+     * @return If the storage learned the skill.
+     */
     default boolean learnSkill(@NonNull ManasSkill skill, MutableComponent component) {
         return learnSkill(skill.createDefaultInstance(), component);
     }
 
+    /**
+     * @param instance The instance to be learned
+     * @return If the storage learned the instance.
+     */
     default boolean learnSkill(ManasSkillInstance instance) {
         return learnSkill(instance, Component.translatable("manascore.skill.learn_skill", instance.getChatDisplayName(true)));
     }
 
+    /**
+     * @param instance The instance to be learned
+     * @param component Shown to the owner of the storage if the skill was learned successfully.
+     * @return If the storage learned the instance.
+     */
     boolean learnSkill(ManasSkillInstance instance, MutableComponent component);
 
+    /**
+     * Returns an optional containing a {@link ManasSkillInstance} corresponding to the provided skillId if present.
+     */
     Optional<ManasSkillInstance> getSkill(@NotNull ResourceLocation skillId);
 
+    /**
+     * Returns an optional containing a {@link ManasSkillInstance} corresponding to the provided {@link ManasSkill} if present.
+     */
     default Optional<ManasSkillInstance> getSkill(@NonNull ManasSkill skill) {
         return getSkill(skill.getRegistryName());
     }
 
+    /**
+     * Removes a {@link ManasSkillInstance} from this object if present.
+     * @param skillId Same as {@link ManasSkillInstance#getSkillId()} of the instance to be removed
+     * @param component If not null, played to the owner if the skill is removed.
+     */
     void forgetSkill(@NotNull ResourceLocation skillId, @Nullable MutableComponent component);
 
+    /**
+     * Removes a {@link ManasSkillInstance} from this object if present.
+     * @param skillId Same as {@link ManasSkillInstance#getSkillId()} of the instance to be removed
+     */
     default void forgetSkill(@NotNull ResourceLocation skillId) {
         forgetSkill(skillId, null);
     }
 
+    /**
+     * Removes a {@link ManasSkillInstance} from this object if present.
+     * <p>
+     * See {@link Skills#forgetSkill(ResourceLocation, MutableComponent)}
+     * @param skill Uses {@link ManasSkill#getRegistryName()} as the resource location of the skill to be removed.
+     * @param component If not null, played to the owner if the skill is removed.
+     */
     default void forgetSkill(@NonNull ManasSkill skill, @Nullable MutableComponent component) {
         forgetSkill(skill.getRegistryName(), component);
     }
 
+    /**
+     * Removes a {@link ManasSkillInstance} from this object if present.
+     * <p>
+     * See {@link Skills#forgetSkill(ResourceLocation)}
+     * @param skill Uses {@link ManasSkill#getRegistryName()} as the resource location of the skill to be removed.
+     */
     default void forgetSkill(@NonNull ManasSkill skill) {
         forgetSkill(skill.getRegistryName());
     }
 
+    /**
+     * Removes a {@link ManasSkillInstance} from this object if present.
+     * <p>
+     * See {@link Skills#forgetSkill(ResourceLocation, MutableComponent)}
+     * @param instance Uses {@link ManasSkillInstance#getSkillId()} to determine the skill to be removed
+     * @param component If not null, played to the owner if the skill is removed.
+     */
     default void forgetSkill(@NonNull ManasSkillInstance instance, @Nullable MutableComponent component) {
         forgetSkill(instance.getSkillId(), component);
     }
 
+    /**
+     * Removes a {@link ManasSkillInstance} from this object if present.
+     * <p>
+     * See {@link Skills#forgetSkill(ResourceLocation)}
+     * @param instance Uses {@link ManasSkillInstance#getSkillId()} to determine the skill to be removed
+     */
     default void forgetSkill(@NonNull ManasSkillInstance instance) {
         forgetSkill(instance.getSkillId());
     }
 
+    /**
+     * Runs the provided {@link BiConsumer} over all {@link ManasSkillInstance} possessed by the storage.
+     */
     void forEachSkill(BiConsumer<SkillStorage, ManasSkillInstance> skillInstanceConsumer);
 }

--- a/skill-common/src/main/java/io/github/manasmods/manascore/skill/impl/SkillStorage.java
+++ b/skill-common/src/main/java/io/github/manasmods/manascore/skill/impl/SkillStorage.java
@@ -5,8 +5,6 @@
 
 package io.github.manasmods.manascore.skill.impl;
 
-import com.google.common.collect.ArrayListMultimap;
-import com.google.common.collect.Multimap;
 import dev.architectury.event.EventResult;
 import dev.architectury.event.events.common.EntityEvent;
 import dev.architectury.event.events.common.PlayerEvent;
@@ -14,7 +12,6 @@ import io.github.manasmods.manascore.network.api.util.Changeable;
 import io.github.manasmods.manascore.skill.ManasCoreSkill;
 import io.github.manasmods.manascore.skill.ModuleConstants;
 import io.github.manasmods.manascore.skill.api.*;
-import io.github.manasmods.manascore.skill.impl.data.ManascoreEntityTags;
 import io.github.manasmods.manascore.storage.api.Storage;
 import io.github.manasmods.manascore.storage.api.StorageEvents;
 import io.github.manasmods.manascore.storage.api.StorageKey;
@@ -29,7 +26,6 @@ import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.LivingEntity;
-import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.Level;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
@@ -45,7 +41,6 @@ public class SkillStorage  extends Storage implements Skills {
     private static StorageKey<SkillStorage> key = null;
     public static final int INSTANCE_UPDATE = 20;
     public static final int PASSIVE_SKILL = 100;
-    public static final Multimap<UUID, TickingSkill> tickingSkills = ArrayListMultimap.create();
     private static final String SKILL_LIST_KEY = "skills";
 
     public static void init() {
@@ -96,7 +91,7 @@ public class SkillStorage  extends Storage implements Skills {
             if (level.isClientSide()) return;
             SkillStorage storage = SkillAPI.getSkillsFrom(entity);
             handleSkillTick(entity, level, storage);
-            if (entity instanceof Player player) handleSkillHeldTick(player, storage);
+            handleSkillHeldTick(entity, storage);
         });
 
         PlayerEvent.PLAYER_QUIT.register(SkillStorage::removeTickingSkill);
@@ -135,7 +130,6 @@ public class SkillStorage  extends Storage implements Skills {
     }
 
     private static void checkSkillTimers(LivingEntity entity, Skills storage) {
-        ManascoreEntityTags
         if (!storage.shouldActiveTick()) return;
         List<ManasSkillInstance> toBeRemoved = new ArrayList<>();
 
@@ -172,23 +166,24 @@ public class SkillStorage  extends Storage implements Skills {
         }
     }
 
-    private static void handleSkillHeldTick(Player player, SkillStorage storage) {
-        if (!tickingSkills.containsKey(player.getUUID())) return;
-        tickingSkills.get(player.getUUID()).removeIf(skill -> {
-            if (!skill.tick(storage, player)) {
+    private static void handleSkillHeldTick(LivingEntity livingEntity, SkillStorage storage) {
+        if (storage.heldSkills.isEmpty()) return;
+        for (TickingSkill skill : List.copyOf(storage.heldSkills)) {
+            if (!skill.tick(storage, livingEntity)) {
                 Optional<ManasSkillInstance> instance = storage.getSkill(skill.getSkill());
-                if (instance.isEmpty()) return true;
-                skill.getSkill().removeAttributeModifiers(instance.get(), player, skill.getMode());
-                storage.checkAndMarkDirty(instance.get());
-                return true;
+                instance.ifPresent(skillInstance -> {
+                    skill.getSkill().removeAttributeModifiers(skillInstance, livingEntity, skill.getMode());
+                    storage.checkAndMarkDirty(skillInstance);
+                });
+                storage.heldSkills.remove(skill);
             } else storage.markDirty();
-            return false;
-        });
+        }
     }
 
     private final Map<ResourceLocation, ManasSkillInstance> skillInstances = new ConcurrentHashMap<>();
     private boolean hasRemovedSkills = false;
     private boolean hasCooldowns = false;
+    public ArrayList<TickingSkill> heldSkills = new ArrayList<>(0);
 
     protected SkillStorage(LivingEntity holder) {
         super(holder);
@@ -266,10 +261,12 @@ public class SkillStorage  extends Storage implements Skills {
         }
 
         skill.removeAttributeModifiers(getOwner(), mode);
-        if (!heldInterrupt) {
-            UUID ownerID = getOwner().getUUID();
-            if (tickingSkills.containsKey(ownerID))
-                tickingSkills.get(ownerID).removeIf(tickingSkill -> tickingSkill.matches(skill.getSkill(), mode));
+        if (!heldInterrupt && !this.heldSkills.isEmpty()) {
+            for (TickingSkill tickingSkill : List.copyOf(this.heldSkills)) {
+                if (tickingSkill.matches(skill.getSkill(), mode)) {
+                    this.heldSkills.remove(tickingSkill);
+                }
+            }
         }
         this.checkAndMarkDirty(skillInstance);
     }
@@ -324,16 +321,15 @@ public class SkillStorage  extends Storage implements Skills {
         return (LivingEntity) this.holder;
     }
 
-    public static void removeTickingSkill(Player player) {
-        Multimap<UUID, TickingSkill> multimap = tickingSkills;
-        if (multimap.containsKey(player.getUUID())) {
-            for (TickingSkill skill : multimap.get(player.getUUID())) {
-                Optional<ManasSkillInstance> instance = SkillAPI.getSkillsFrom(player).getSkill(skill.getSkill());
-                if (instance.isEmpty()) continue;
-                skill.getSkill().removeAttributeModifiers(instance.get(), player, skill.getMode());
-            }
-            multimap.removeAll(player.getUUID());
+    public static void removeTickingSkill(LivingEntity livingEntity) {
+        SkillStorage storage = SkillAPI.getSkillsFrom(livingEntity);
+        for (TickingSkill skill : List.copyOf(storage.heldSkills)) {
+            Optional<ManasSkillInstance> instance = SkillAPI.getSkillsFrom(livingEntity).getSkill(skill.getSkill());
+            instance.ifPresent(skillInstance -> {
+                skill.getSkill().removeAttributeModifiers(skillInstance, livingEntity, skill.getMode());
+            });
         }
+        storage.heldSkills.clear();
     }
 
     public void markActiveTick() {

--- a/skill-common/src/main/java/io/github/manasmods/manascore/skill/impl/SkillStorage.java
+++ b/skill-common/src/main/java/io/github/manasmods/manascore/skill/impl/SkillStorage.java
@@ -31,6 +31,7 @@ import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.Level;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -46,15 +47,6 @@ public class SkillStorage  extends Storage implements Skills {
     public static final int PASSIVE_SKILL = 100;
     public static final Multimap<UUID, TickingSkill> tickingSkills = ArrayListMultimap.create();
     private static final String SKILL_LIST_KEY = "skills";
-    /*
-    private static final StorageEvents.RegisterStorage<Entity> listener = new StorageEvents.RegisterStorage<Entity>() {
-        @Override
-        public void register(StorageEvents.StorageRegistry<Entity> registry) {
-            ManasCoreSkill.LOG.info("ManasSkill storage event triggered");
-            key = registry.register(ResourceLocation.fromNamespaceAndPath(ModuleConstants.MOD_ID, "skill_storage"), SkillStorage.class, LivingEntity.class::isInstance, target -> new SkillStorage((LivingEntity) target));
-            ManasCoreSkill.LOG.info(key != null ? "ManasSkill storage Key registered " + key.toString() : "ManasSkill storage Key failed to register");
-        }
-    };*/
 
     public static void init() {
         StorageEvents.RegisterStorage<Entity> listener = new StorageEvents.RegisterStorage<Entity>() {
@@ -116,13 +108,10 @@ public class SkillStorage  extends Storage implements Skills {
         if (server == null) return;
 
         boolean shouldPassiveConsume = server.getTickCount() % INSTANCE_UPDATE == 0;
-        if (!shouldPassiveConsume) return;
-        checkPlayerOnlyEffects(entity, storage);
+        if (shouldPassiveConsume) checkSkillTimers(entity, storage);
 
         boolean passiveSkillActivate = server.getTickCount() % PASSIVE_SKILL == 0;
-        if (!passiveSkillActivate) return;
-
-        tickSkills(entity, storage);
+        if (passiveSkillActivate) tickSkills(entity, storage);
     }
 
     private static void tickSkills(LivingEntity entity, Skills storage) {
@@ -145,14 +134,17 @@ public class SkillStorage  extends Storage implements Skills {
         }
     }
 
-    private static void checkPlayerOnlyEffects(LivingEntity entity, Skills storage) {
-        if (!entity.getType().is(ManascoreEntityTags.SKILL_COOLDOWN_ALLOWED)) return;
+    private static void checkSkillTimers(LivingEntity entity, Skills storage) {
+        ManascoreEntityTags
+        if (!storage.shouldActiveTick()) return;
         List<ManasSkillInstance> toBeRemoved = new ArrayList<>();
 
+        boolean shouldContinueToTick = false;
         for (ManasSkillInstance instance : storage.getLearnedSkills()) {
             // Update cooldown
             for (int i = 0; i < instance.getModes(); i++) {
                 if (!instance.onCoolDown(i)) continue;
+                shouldContinueToTick = true;
                 int currentCooldown = instance.getCoolDown(i);
                 Changeable<Integer> newCooldown = Changeable.of(Math.max(0, currentCooldown - 1));
                 if (!SkillEvents.SKILL_UPDATE_COOLDOWN.invoker().cooldown(instance, entity, i, currentCooldown, newCooldown).isFalse())
@@ -162,6 +154,7 @@ public class SkillStorage  extends Storage implements Skills {
 
             // Update temporary skill timer
             if (!instance.isTemporarySkill()) continue;
+            shouldContinueToTick = true;
             instance.decreaseRemoveTime(1);
             storage.checkAndMarkDirty(instance);
 
@@ -172,6 +165,10 @@ public class SkillStorage  extends Storage implements Skills {
         // Remove temporary skills
         for (ManasSkillInstance instance : toBeRemoved) {
             storage.forgetSkill(instance);
+        }
+
+        if (!shouldContinueToTick) {
+            storage.clearActiveTick();
         }
     }
 
@@ -191,6 +188,7 @@ public class SkillStorage  extends Storage implements Skills {
 
     private final Map<ResourceLocation, ManasSkillInstance> skillInstances = new ConcurrentHashMap<>();
     private boolean hasRemovedSkills = false;
+    private boolean hasCooldowns = false;
 
     protected SkillStorage(LivingEntity holder) {
         super(holder);
@@ -202,7 +200,9 @@ public class SkillStorage  extends Storage implements Skills {
 
     public void updateSkill(@NonNull ManasSkillInstance updatedInstance, boolean sync) {
         updatedInstance.markDirty();
+        updatedInstance.setOwningStorage(this);
         this.skillInstances.put(updatedInstance.getSkillId(), updatedInstance);
+        this.checkAndMarkActiveTick(updatedInstance);
         if (sync) markDirty();
     }
 
@@ -217,7 +217,9 @@ public class SkillStorage  extends Storage implements Skills {
         if (result.isFalse()) return false;
 
         instance.markDirty();
+        instance.setOwningStorage(this);
         this.skillInstances.put(instance.getSkillId(), instance);
+        this.checkAndMarkActiveTick(instance);
         if (unlockMessage.isPresent()) getOwner().sendSystemMessage(unlockMessage.get());
         instance.onLearnSkill(this.getOwner());
         markDirty();
@@ -291,7 +293,9 @@ public class SkillStorage  extends Storage implements Skills {
         for (Tag tag : data.getList(SKILL_LIST_KEY, Tag.TAG_COMPOUND)) {
             try {
                 ManasSkillInstance instance = ManasSkillInstance.fromNBT((CompoundTag) tag);
+                instance.setOwningStorage(this);
                 this.skillInstances.put(instance.getSkillId(), instance);
+                this.checkAndMarkActiveTick(instance);
             } catch (Exception e) {
                 ManasCoreSkill.LOG.error("Failed to load skill instance from NBT", e);
             }
@@ -315,7 +319,8 @@ public class SkillStorage  extends Storage implements Skills {
         }
     }
 
-    protected LivingEntity getOwner() {
+    @Override
+    public LivingEntity getOwner() {
         return (LivingEntity) this.holder;
     }
 
@@ -328,6 +333,33 @@ public class SkillStorage  extends Storage implements Skills {
                 skill.getSkill().removeAttributeModifiers(instance.get(), player, skill.getMode());
             }
             multimap.removeAll(player.getUUID());
+        }
+    }
+
+    public void markActiveTick() {
+        this.hasCooldowns = true;
+    }
+
+    @ApiStatus.Internal
+    public void clearActiveTick() {
+        this.hasCooldowns = false;
+    }
+
+    public boolean shouldActiveTick() {
+        return this.hasCooldowns;
+    }
+
+    private void checkAndMarkActiveTick(ManasSkillInstance instance) {
+        if (this.shouldActiveTick()) return;
+        if (instance.isTemporarySkill()) {
+            this.markActiveTick();
+            return;
+        }
+        for (int i = 0; i < instance.getModes(); i++) {
+            if (instance.getCoolDown(i) > 0) {
+                this.markActiveTick();
+                return;
+            }
         }
     }
 }

--- a/skill-common/src/main/java/io/github/manasmods/manascore/skill/impl/TickingSkill.java
+++ b/skill-common/src/main/java/io/github/manasmods/manascore/skill/impl/TickingSkill.java
@@ -7,6 +7,7 @@ package io.github.manasmods.manascore.skill.impl;
 
 import io.github.manasmods.manascore.skill.api.ManasSkill;
 import io.github.manasmods.manascore.skill.api.ManasSkillInstance;
+import io.github.manasmods.manascore.skill.api.SkillAPI;
 import lombok.Getter;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.player.Player;
@@ -60,24 +61,23 @@ public class TickingSkill {
         return this.skill == skill && this.mode == mode && this.keyNumber == keyNumber;
     }
 
-    public static void addTickingSkill(Player player, ManasSkill skill, int mode, int keyNumber) {
-        UUID uuid = player.getUUID();
-        Collection<TickingSkill> skills = SkillStorage.tickingSkills.get(uuid);
-        for (TickingSkill tickingSkill : skills) if (tickingSkill.matches(skill, mode)) return;
-        SkillStorage.tickingSkills.put(uuid, new TickingSkill(skill, mode, keyNumber));
+    public static void addTickingSkill(LivingEntity livingEntity, ManasSkill skill, int mode, int keyNumber) {
+        SkillStorage storage = SkillAPI.getSkillsFrom(livingEntity);
+        for (TickingSkill tickingSkill : storage.heldSkills) if (tickingSkill.matches(skill, mode)) return;
+        storage.heldSkills.add(new TickingSkill(skill, mode, keyNumber));
     }
 
     public static boolean isTickingSkill(LivingEntity entity, ManasSkill skill, int mode) {
-        UUID uuid = entity.getUUID();
-        for (TickingSkill tickingSkill : SkillStorage.tickingSkills.get(uuid)) {
+        SkillStorage storage = SkillAPI.getSkillsFrom(entity);
+        for (TickingSkill tickingSkill : storage.heldSkills) {
             if (tickingSkill.matches(skill, mode)) return true;
         }
         return false;
     }
 
     public static boolean isTickingSkill(LivingEntity entity, ManasSkill skill) {
-        UUID uuid = entity.getUUID();
-        for (TickingSkill tickingSkill : SkillStorage.tickingSkills.get(uuid)) {
+        SkillStorage storage = SkillAPI.getSkillsFrom(entity);
+        for (TickingSkill tickingSkill : storage.heldSkills) {
             if (tickingSkill.getSkill() == skill) return true;
         }
         return false;

--- a/skill-common/src/main/java/io/github/manasmods/manascore/skill/impl/data/ManascoreEntityTags.java
+++ b/skill-common/src/main/java/io/github/manasmods/manascore/skill/impl/data/ManascoreEntityTags.java
@@ -6,8 +6,6 @@ import net.minecraft.tags.TagKey;
 import net.minecraft.world.entity.EntityType;
 
 public class ManascoreEntityTags {
-    public static TagKey<EntityType<?>> SKILL_COOLDOWN_ALLOWED = modTag("skill_cooldown_allowed");
-
     static TagKey<EntityType<?>> modTag(String name) {
         return create(ResourceLocation.fromNamespaceAndPath("manascore", name));
     }


### PR DESCRIPTION
Skills Cooldown/Temporary skill tick rework

# Description
Update to the skills system so now only entities which have cooldowns/temporary skills are ticked for them, rather than all entities of a type.

## List of changes

- Reworked SkillStorage to use an internal flag for cooldown ticking rather than an an entity flag
- Added documentation for methods inside Skills
- Updated ManasSkillInstance to support the new flag added to SkillStorage
- Removed the now depicated entity flag.
- Made getOwner() a public method in Skills, now ManasSkillInstance can get the owner by going through the storage.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Code Refactoring (non-breaking change which improved the Code Quality)
- [ ] Breaking Code Refactoring (breaking change which improved the Code Quality)
- [X] Documentation update (JavaDoc or Markdown change)
